### PR TITLE
Refactor: hate command to use slash commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "youtube-search": "^1.1.4"
       },
       "devDependencies": {
-        "nodemon": "^2.0.4"
+        "nodemon": "^2.0.15"
       }
     },
     "node_modules/@babel/runtime": {
@@ -3451,21 +3451,21 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.13.tgz",
-      "integrity": "sha512-UMXMpsZsv1UXUttCn6gv8eQPhn6DR4BW+txnL3IN5IHqrCwcrT/yWHfL35UsClGXknTH79r5xbu+6J1zNHuSyA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
+      "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "chokidar": "^3.2.2",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
+        "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.3",
+        "undefsafe": "^2.0.5",
         "update-notifier": "^5.1.0"
       },
       "bin": {
@@ -4618,27 +4618,9 @@
       }
     },
     "node_modules/undefsafe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
-      "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^2.2.0"
-      }
-    },
-    "node_modules/undefsafe/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/undefsafe/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
     "node_modules/unique-string": {
@@ -7833,20 +7815,20 @@
       }
     },
     "nodemon": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.13.tgz",
-      "integrity": "sha512-UMXMpsZsv1UXUttCn6gv8eQPhn6DR4BW+txnL3IN5IHqrCwcrT/yWHfL35UsClGXknTH79r5xbu+6J1zNHuSyA==",
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.15.tgz",
+      "integrity": "sha512-gdHMNx47Gw7b3kWxJV64NI+Q5nfl0y5DgDbiVtShiwa7Z0IZ07Ll4RLFo6AjrhzMtoEZn5PDE3/c2AbVsiCkpA==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.2.2",
-        "debug": "^3.2.6",
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.7",
+        "pstree.remy": "^1.1.8",
         "semver": "^5.7.1",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
-        "undefsafe": "^2.0.3",
+        "undefsafe": "^2.0.5",
         "update-notifier": "^5.1.0"
       },
       "dependencies": {
@@ -8750,30 +8732,10 @@
       }
     },
     "undefsafe": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
-      "integrity": "sha512-nrXZwwXrD/T/JXeygJqdCO6NZZ1L66HrxM/Z7mIq2oPanoN0F1nLx3lwJMu6AwJY69hdixaFQOuoYsMjE5/C2A==",
-      "dev": true,
-      "requires": {
-        "debug": "^2.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,56 +1,57 @@
 {
-  "name": "splite",
-  "version": "2.0.0",
-  "description": "A fully customizable bot built with discord.js",
-  "main": "app.js",
-  "dependencies": {
-    "@discordjs/builders": "^0.6.0",
-    "@discordjs/rest": "^0.1.0-canary.0",
-    "amethyste-api": "^1.1.5",
-    "ascii-table": "0.0.9",
-    "better-sqlite3": "^7.4.3",
-    "cheerio": "^1.0.0-rc.10",
-    "common-tags": "^1.8.0",
-    "discord-player": "^5.1.0",
-    "discord.js": "^13.6.0",
-    "fast-sort": "^3.0.2",
-    "ffmpeg-static": "^4.4.0",
-    "he": "^1.2.0",
-    "jimp": "^0.16.1",
-    "jsdom": "^16.5.3",
-    "minimist": ">=1.2.2",
-    "moment": "^2.29.1",
-    "ms": "^2.1.2",
-    "nekobot-api": "^2.1.0",
-    "node-fetch": "^2.6.1",
-    "node-os-utils": "^1.3.1",
-    "node-pre-gyp": "^0.11.0",
-    "node-schedule": "^1.3.2",
-    "opusscript": "^0.0.8",
-    "prettier": "^2.6.2",
-    "request": "^2.88.2",
-    "twemoji-parser": "^13.0.0",
-    "urban-dictionary": "^3.0.2",
-    "weky": "^3.1.8",
-    "winston": "^3.2.1",
-    "yaml": "^1.8.3",
-    "youtube-search": "^1.1.4"
-  },
-  "devDependencies": {
-    "nodemon": "^2.0.4"
-  },
-  "scripts": {
-    "start": "node app.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/certifiedrehman/spliteBot.git"
-  },
-  "author": "Rehman Ahmadzai",
-  "license": "GPL-3.0",
-  "bugs": {
-    "url": "https://github.com/certifiedrehman/spliteBot"
-  },
-  "basedOn": "https://github.com/sabattle/CalypsoBot"
+   "name": "splite",
+   "version": "2.0.0",
+   "description": "A fully customizable bot built with discord.js",
+   "main": "app.js",
+   "dependencies": {
+      "@discordjs/builders": "^0.6.0",
+      "@discordjs/rest": "^0.1.0-canary.0",
+      "amethyste-api": "^1.1.5",
+      "ascii-table": "0.0.9",
+      "better-sqlite3": "^7.4.3",
+      "cheerio": "^1.0.0-rc.10",
+      "common-tags": "^1.8.0",
+      "discord-player": "^5.1.0",
+      "discord.js": "^13.6.0",
+      "fast-sort": "^3.0.2",
+      "ffmpeg-static": "^4.4.0",
+      "he": "^1.2.0",
+      "jimp": "^0.16.1",
+      "jsdom": "^16.5.3",
+      "minimist": ">=1.2.2",
+      "moment": "^2.29.1",
+      "ms": "^2.1.2",
+      "nekobot-api": "^2.1.0",
+      "node-fetch": "^2.6.1",
+      "node-os-utils": "^1.3.1",
+      "node-pre-gyp": "^0.11.0",
+      "node-schedule": "^1.3.2",
+      "opusscript": "^0.0.8",
+      "prettier": "^2.6.2",
+      "request": "^2.88.2",
+      "twemoji-parser": "^13.0.0",
+      "urban-dictionary": "^3.0.2",
+      "weky": "^3.1.8",
+      "winston": "^3.2.1",
+      "yaml": "^1.8.3",
+      "youtube-search": "^1.1.4"
+   },
+   "devDependencies": {
+      "nodemon": "^2.0.15"
+   },
+   "scripts": {
+      "start": "node app.js",
+      "dev": "nodemon app.js",
+      "test": "echo \"Error: no test specified\" && exit 1"
+   },
+   "repository": {
+      "type": "git",
+      "url": "git+https://github.com/certifiedrehman/spliteBot.git"
+   },
+   "author": "Rehman Ahmadzai",
+   "license": "GPL-3.0",
+   "bugs": {
+      "url": "https://github.com/certifiedrehman/spliteBot"
+   },
+   "basedOn": "https://github.com/sabattle/CalypsoBot"
 }

--- a/src/commands/fun/hate.js
+++ b/src/commands/fun/hate.js
@@ -1,37 +1,96 @@
-const Command = require('../Command.js');
-const {MessageEmbed, MessageAttachment} = require('discord.js');
-const {fail, load} = require("../../utils/emojis.json")
+const Command = require("../Command.js");
+const { MessageEmbed, MessageAttachment } = require("discord.js");
+const { fail, load } = require("../../utils/emojis.json");
+const { SlashCommandBuilder } = require("@discordjs/builders");
 
 module.exports = class HateCommand extends Command {
-    constructor(client) {
-        super(client, {
-            name: 'hate',
-            aliases: ['fuck', 'allmyhomies', 'homies'],
-            usage: 'hate <text>',
-            description: 'Generates an "all my homies hate" image with provided text',
-            type: client.types.FUN,
-            examples: [`hate ${client.name} is the best bot!`],
-            cooldown: 5
-        });
-    }
+   constructor(client) {
+      super(client, {
+         name: "hate",
+         aliases: ["fuck", "allmyhomies", "homies"],
+         usage: "hate <text>",
+         description:
+            'Generates an "all my homies hate" image with provided text',
+         type: client.types.FUN,
+         examples: [`hate ${client.name} is the best bot!`],
+         cooldown: 5,
+         slashCommand: new SlashCommandBuilder()
+            .setName("hate")
+            .setDescription(
+               "Generates an 'all my homies hate' image with provided text"
+            )
+            .addStringOption((option) => {
+               return option
+                  .setName("text")
+                  .setDescription("Text to put in the image")
+                  .setRequired(true);
+            }),
+      });
+   }
 
-    async run(message, args) {
+   async interact(interaction, args) {
+      try {
+         const text = await interaction.client.utils.replaceMentionsWithNames(
+            args.join(" "),
+            interaction.guild
+         );
+         const buffer = await interaction.client.utils.generateImgFlipImage(
+            242461078,
+            `${text}`,
+            `${text}`,
+            "#EBDBD1",
+            "#2E251E"
+         );
 
+         if (buffer) {
+            const attachment = new MessageAttachment(
+               buffer,
+               "allmyhomieshate.png"
+            );
 
-        message.channel.send({embeds: [new MessageEmbed().setDescription(`${load} Loading...`)]}).then(async msg => {
+            await interaction.reply({ files: [attachment] });
+            // await msg.delete();
+         }
+      } catch (e) {
+         await interaction.reply({
+            embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
+         });
+      }
+   }
+
+   async run(message, args) {
+      message.channel
+         .send({
+            embeds: [new MessageEmbed().setDescription(`${load} Loading...`)],
+         })
+         .then(async (msg) => {
             try {
-                const text = await message.client.utils.replaceMentionsWithNames(args.join(' '), message.guild)
-                const buffer = await msg.client.utils.generateImgFlipImage(242461078, `${text}`, `${text}`, '#EBDBD1', '#2E251E')
+               const text = await message.client.utils.replaceMentionsWithNames(
+                  args.join(" "),
+                  message.guild
+               );
+               const buffer = await msg.client.utils.generateImgFlipImage(
+                  242461078,
+                  `${text}`,
+                  `${text}`,
+                  "#EBDBD1",
+                  "#2E251E"
+               );
 
-                if (buffer) {
-                    const attachment = new MessageAttachment(buffer, "allmyhomieshate.png");
+               if (buffer) {
+                  const attachment = new MessageAttachment(
+                     buffer,
+                     "allmyhomieshate.png"
+                  );
 
-                    await message.channel.send({files: [attachment]})
-                    await msg.delete()
-                }
+                  await message.channel.send({ files: [attachment] });
+                  await msg.delete();
+               }
             } catch (e) {
-                await msg.edit({embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)]})
+               await msg.edit({
+                  embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
+               });
             }
-        })
-    }
+         });
+   }
 };

--- a/src/commands/fun/hate.js
+++ b/src/commands/fun/hate.js
@@ -29,68 +29,45 @@ module.exports = class HateCommand extends Command {
    }
 
    async interact(interaction, args) {
-      try {
-         const text = await interaction.client.utils.replaceMentionsWithNames(
-            args.join(" "),
-            interaction.guild
-         );
-         const buffer = await interaction.client.utils.generateImgFlipImage(
-            242461078,
-            `${text}`,
-            `${text}`,
-            "#EBDBD1",
-            "#2E251E"
-         );
-
-         if (buffer) {
-            const attachment = new MessageAttachment(
-               buffer,
-               "allmyhomieshate.png"
-            );
-
-            await interaction.reply({ files: [attachment] });
-            // await msg.delete();
-         }
-      } catch (e) {
-         await interaction.reply({
-            embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
-         });
-      }
+      runHate.call(this, interaction, args);
    }
 
    async run(message, args) {
-      message.channel
-         .send({
-            embeds: [new MessageEmbed().setDescription(`${load} Loading...`)],
-         })
-         .then(async (msg) => {
-            try {
-               const text = await message.client.utils.replaceMentionsWithNames(
-                  args.join(" "),
-                  message.guild
-               );
-               const buffer = await msg.client.utils.generateImgFlipImage(
-                  242461078,
-                  `${text}`,
-                  `${text}`,
-                  "#EBDBD1",
-                  "#2E251E"
-               );
-
-               if (buffer) {
-                  const attachment = new MessageAttachment(
-                     buffer,
-                     "allmyhomieshate.png"
-                  );
-
-                  await message.channel.send({ files: [attachment] });
-                  await msg.delete();
-               }
-            } catch (e) {
-               await msg.edit({
-                  embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
-               });
-            }
-         });
+      runHate.call(this, message, args);
    }
 };
+
+/**
+ * Run the hate command by responding to the message with an image
+ * @param {any} interaction interaction object
+ * @param {any} args arguments
+ */
+async function runHate(interaction, args) {
+   try {
+      const text = await interaction.client.utils.replaceMentionsWithNames(
+         args.join(" "),
+         interaction.guild
+      );
+      const buffer = await interaction.client.utils.generateImgFlipImage(
+         242461078,
+         `${text}`,
+         `${text}`,
+         "#EBDBD1",
+         "#2E251E"
+      );
+
+      if (buffer) {
+         const attachment = new MessageAttachment(
+            buffer,
+            "allmyhomieshate.png"
+         );
+
+         await interaction.reply({ files: [attachment] });
+         // await msg.delete();
+      }
+   } catch (e) {
+      await interaction.reply({
+         embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
+      });
+   }
+}

--- a/src/commands/fun/hate.js
+++ b/src/commands/fun/hate.js
@@ -29,11 +29,11 @@ module.exports = class HateCommand extends Command {
    }
 
    async interact(interaction, args) {
-      runHate.call(this, interaction, args);
+      await runHate.call(this, interaction, args, false);
    }
 
    async run(message, args) {
-      runHate.call(this, message, args);
+      await runHate.call(this, message, args, true);
    }
 };
 
@@ -41,13 +41,15 @@ module.exports = class HateCommand extends Command {
  * Run the hate command by responding to the message with an image
  * @param {any} interaction interaction object
  * @param {any} args arguments
+ * @param {boolean} [textCommand=false] whether the command is being run as a slash command
  */
-async function runHate(interaction, args) {
+async function runHate(interaction, args, textCommand = false) {
    try {
       const text = await interaction.client.utils.replaceMentionsWithNames(
          args.join(" "),
          interaction.guild
       );
+      console.log("before image flip");
       const buffer = await interaction.client.utils.generateImgFlipImage(
          242461078,
          `${text}`,
@@ -55,19 +57,29 @@ async function runHate(interaction, args) {
          "#EBDBD1",
          "#2E251E"
       );
-
+      console.log("after image flip");
       if (buffer) {
          const attachment = new MessageAttachment(
             buffer,
             "allmyhomieshate.png"
          );
 
-         await interaction.reply({ files: [attachment] });
-         // await msg.delete();
+         if (textCommand) {
+            await interaction.channel.send({ files: [attachment] });
+            await interaction.delete();
+         } else {
+            await interaction.reply({ files: [attachment] });
+         }
       }
    } catch (e) {
-      await interaction.reply({
-         embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
-      });
+      if (textCommand) {
+         await interaction.channel.send({
+            embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
+         });
+      } else {
+         await interaction.reply({
+            embeds: [new MessageEmbed().setDescription(`${fail} ${e}`)],
+         });
+      }
    }
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,16 +1,16 @@
-const {MessageEmbed, Collection} = require('discord.js');
-const schedule = require('node-schedule');
-const {stripIndent} = require('common-tags');
-const emojis = require("./emojis.json")
-const request = require('request')
-const config = require('../../config.json')
+const { MessageEmbed, Collection } = require("discord.js");
+const schedule = require("node-schedule");
+const { stripIndent } = require("common-tags");
+const emojis = require("./emojis.json");
+const request = require("request");
+const config = require("../../config.json");
 
 /**
  * Capitalizes a string
  * @param {string} string
  */
 function capitalize(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 /**
@@ -19,11 +19,11 @@ function capitalize(string) {
  * @param {*} value
  */
 function removeElement(arr, value) {
-    const index = arr.indexOf(value);
-    if (index > -1) {
-        arr.splice(index, 1);
-    }
-    return arr;
+   const index = arr.indexOf(value);
+   if (index > -1) {
+      arr.splice(index, 1);
+   }
+   return arr;
 }
 
 /**
@@ -32,12 +32,12 @@ function removeElement(arr, value) {
  * @param {int} maxLen
  */
 function trimArray(arr, maxLen = 10) {
-    if (arr.length > maxLen) {
-        const len = arr.length - maxLen;
-        arr = arr.slice(0, maxLen);
-        arr.push(`and **${len}** more...`);
-    }
-    return arr;
+   if (arr.length > maxLen) {
+      const len = arr.length - maxLen;
+      arr = arr.slice(0, maxLen);
+      arr.push(`and **${len}** more...`);
+   }
+   return arr;
 }
 
 /**
@@ -46,15 +46,16 @@ function trimArray(arr, maxLen = 10) {
  * @param {int} maxLen
  * @param {string} joinChar
  */
-function trimStringFromArray(arr, maxLen = 2048, joinChar = '\n') {
-    let string = arr.join(joinChar);
-    const diff = maxLen - 15; // Leave room for "And ___ more..."
-    if (string.length > maxLen) {
-        string = string.slice(0, string.length - (string.length - diff));
-        string = string.slice(0, string.lastIndexOf(joinChar));
-        string = string + `\nAnd **${arr.length - string.split('\n').length}** more...`;
-    }
-    return string;
+function trimStringFromArray(arr, maxLen = 2048, joinChar = "\n") {
+   let string = arr.join(joinChar);
+   const diff = maxLen - 15; // Leave room for "And ___ more..."
+   if (string.length > maxLen) {
+      string = string.slice(0, string.length - (string.length - diff));
+      string = string.slice(0, string.lastIndexOf(joinChar));
+      string =
+         string + `\nAnd **${arr.length - string.split("\n").length}** more...`;
+   }
+   return string;
 }
 
 /**
@@ -64,23 +65,26 @@ function trimStringFromArray(arr, maxLen = 2048, joinChar = '\n') {
  * @param {int} interval
  */
 function getRange(arr, current, interval) {
-    const max = (arr.length > current + interval) ? current + interval : arr.length;
-    current = current + 1;
-    return (arr.length == 1 || arr.length == current || interval == 1) ? `[${current}]` : `[${current} - ${max}]`;
+   const max =
+      arr.length > current + interval ? current + interval : arr.length;
+   current = current + 1;
+   return arr.length == 1 || arr.length == current || interval == 1
+      ? `[${current}]`
+      : `[${current} - ${max}]`;
 }
-
 
 /**
  * Gets the ordinal numeral of a number
  * @param {int} number
  */
 function getOrdinalNumeral(number) {
-    let numberStr = number.toString();
-    if (numberStr === '11' || numberStr === '12' || numberStr === '13') return numberStr + 'th';
-    if (numberStr.endsWith(1)) return numberStr + 'st';
-    else if (numberStr.endsWith(2)) return numberStr + 'nd';
-    else if (numberStr.endsWith(3)) return numberStr + 'rd';
-    else return numberStr + 'th';
+   let numberStr = number.toString();
+   if (numberStr === "11" || numberStr === "12" || numberStr === "13")
+      return numberStr + "th";
+   if (numberStr.endsWith(1)) return numberStr + "st";
+   else if (numberStr.endsWith(2)) return numberStr + "nd";
+   else if (numberStr.endsWith(3)) return numberStr + "rd";
+   else return numberStr + "th";
 }
 
 /**
@@ -90,22 +94,25 @@ function getOrdinalNumeral(number) {
  * @param modLog
  */
 async function getCaseNumber(client, guild, modLog) {
+   const message = (await modLog.messages.fetch({ limit: 100 }))
+      .filter(
+         (m) =>
+            m.member === guild.me &&
+            m.embeds[0] &&
+            m.embeds[0].type == "rich" &&
+            m.embeds[0].footer &&
+            m.embeds[0].footer.text &&
+            m.embeds[0].footer.text.startsWith("Case")
+      )
+      .first();
 
-    const message = (await modLog.messages.fetch({limit: 100})).filter(m => m.member === guild.me &&
-        m.embeds[0] &&
-        m.embeds[0].type == 'rich' &&
-        m.embeds[0].footer &&
-        m.embeds[0].footer.text &&
-        m.embeds[0].footer.text.startsWith('Case')
-    ).first();
+   if (message) {
+      const footer = message.embeds[0].footer.text;
+      const num = parseInt(footer.split("#").pop());
+      if (!isNaN(num)) return num + 1;
+   }
 
-    if (message) {
-        const footer = message.embeds[0].footer.text;
-        const num = parseInt(footer.split('#').pop());
-        if (!isNaN(num)) return num + 1;
-    }
-
-    return 1;
+   return 1;
 }
 
 /**
@@ -113,10 +120,10 @@ async function getCaseNumber(client, guild, modLog) {
  * @param {...*} args
  */
 function getStatus(...args) {
-    for (const arg of args) {
-        if (!arg) return 'disabled';
-    }
-    return 'enabled';
+   for (const arg of args) {
+      if (!arg) return "disabled";
+   }
+   return "enabled";
 }
 
 /**
@@ -124,21 +131,23 @@ function getStatus(...args) {
  * @param {string} message
  */
 function replaceKeywords(message) {
-    if (!message) return message;
-    else return message
-        .replace(/\?member/g, '`?member`')
-        .replace(/\?username/g, '`?username`')
-        .replace(/\?tag/g, '`?tag`')
-        .replace(/\?size/g, '`?size`');
+   if (!message) return message;
+   else
+      return message
+         .replace(/\?member/g, "`?member`")
+         .replace(/\?username/g, "`?username`")
+         .replace(/\?tag/g, "`?tag`")
+         .replace(/\?size/g, "`?size`");
 }
 
 function getEmojiForJoinVoting(guild, client) {
-    const {joinvoting_emoji: joinVotingEmoji} = client.db.settings.selectJoinVotingMessage.get(guild.id)
-    let emoji = joinVotingEmoji || '`None`';
-    if (emoji && !isNaN(joinVotingEmoji)) {
-        emoji = guild.emojis.cache.find(e => e.id === emoji) || null;
-    }
-    return emoji;
+   const { joinvoting_emoji: joinVotingEmoji } =
+      client.db.settings.selectJoinVotingMessage.get(guild.id);
+   let emoji = joinVotingEmoji || "`None`";
+   if (emoji && !isNaN(joinVotingEmoji)) {
+      emoji = guild.emojis.cache.find((e) => e.id === emoji) || null;
+   }
+   return emoji;
 }
 
 /**
@@ -146,13 +155,14 @@ function getEmojiForJoinVoting(guild, client) {
  * @param {string} message
  */
 function replaceCrownKeywords(message) {
-    if (!message) return message;
-    else return message
-        .replace(/\?member/g, '`?member`')
-        .replace(/\?username/g, '`?username`')
-        .replace(/\?tag/g, '`?tag`')
-        .replace(/\?role/g, '`?role`')
-        .replace(/\?points/g, '`?points`');
+   if (!message) return message;
+   else
+      return message
+         .replace(/\?member/g, "`?member`")
+         .replace(/\?username/g, "`?username`")
+         .replace(/\?tag/g, "`?tag`")
+         .replace(/\?role/g, "`?role`")
+         .replace(/\?points/g, "`?points`");
 }
 
 /**
@@ -162,75 +172,100 @@ function replaceCrownKeywords(message) {
  * @param crownRoleId
  */
 async function transferCrown(client, guild, crownRoleId) {
+   const crownRole = guild.roles.cache.get(crownRoleId);
 
-    const crownRole = guild.roles.cache.get(crownRoleId);
-
-    // If crown role is unable to be found
-    if (!crownRole) {
-        return client.sendSystemErrorMessage(guild, 'crown update', stripIndent`
+   // If crown role is unable to be found
+   if (!crownRole) {
+      return client.sendSystemErrorMessage(
+         guild,
+         "crown update",
+         stripIndent`
       Unable to transfer crown role, it may have been modified or deleted
-    `);
-    }
+    `
+      );
+   }
 
-    const leaderboard = client.db.users.selectLeaderboard.all(guild.id);
-    const winner = guild.members.cache.get(leaderboard[0].user_id);
-    const points = client.db.users.selectPoints.pluck().get(winner.id, guild.id);
-    let quit = false;
+   const leaderboard = client.db.users.selectLeaderboard.all(guild.id);
+   const winner = guild.members.cache.get(leaderboard[0].user_id);
+   const points = client.db.users.selectPoints.pluck().get(winner.id, guild.id);
+   let quit = false;
 
-    // Remove role from losers
-    await Promise.all(guild.members.cache.map(async member => { // Good alternative to handling async forEach
-        if (member.roles.cache.has(crownRole.id)) {
+   // Remove role from losers
+   await Promise.all(
+      guild.members.cache.map(async (member) => {
+         // Good alternative to handling async forEach
+         if (member.roles.cache.has(crownRole.id)) {
             try {
-                await member.roles.remove(crownRole);
+               await member.roles.remove(crownRole);
             } catch (err) {
+               quit = true;
+               // Clear points
+               client.db.users.wipeAllPoints.run(guild.id);
 
-                quit = true;
-                // Clear points
-                client.db.users.wipeAllPoints.run(guild.id);
-
-                return client.sendSystemErrorMessage(guild, 'crown update', stripIndent`
+               return client.sendSystemErrorMessage(
+                  guild,
+                  "crown update",
+                  stripIndent`
           Unable to transfer crown role, please check the role hierarchy and ensure I have the Manage Roles permission
-        `, err.message);
+        `,
+                  err.message
+               );
             }
-        }
-    }));
+         }
+      })
+   );
 
-    // Clear points
-    client.db.users.wipeAllPoints.run(guild.id);
+   // Clear points
+   client.db.users.wipeAllPoints.run(guild.id);
 
-    if (quit) return;
+   if (quit) return;
 
-    // Give role to winner
-    try {
-        await winner.roles.add(crownRole);
-    } catch (err) {
-        return client.sendSystemErrorMessage(guild, 'crown update', stripIndent`
+   // Give role to winner
+   try {
+      await winner.roles.add(crownRole);
+   } catch (err) {
+      return client.sendSystemErrorMessage(
+         guild,
+         "crown update",
+         stripIndent`
       Unable to transfer crown role, please check the role hierarchy and ensure I have the Manage Roles permission
-    `, err.message);
-    }
+    `,
+         err.message
+      );
+   }
 
-    // Get crown channel and crown channel
-    let {crown_channel_id: crownChannelId, crown_message: crownMessage} =
-        client.db.settings.selectCrown.get(guild.id);
-    const crownChannel = guild.channels.cache.get(crownChannelId);
+   // Get crown channel and crown channel
+   let { crown_channel_id: crownChannelId, crown_message: crownMessage } =
+      client.db.settings.selectCrown.get(guild.id);
+   const crownChannel = guild.channels.cache.get(crownChannelId);
 
-    // Send crown message
-    if (
-        crownChannel &&
-        crownChannel.viewable &&
-        crownChannel.permissionsFor(guild.me).has(['SEND_MESSAGES', 'EMBED_LINKS']) &&
-        crownMessage
-    ) {
-        crownMessage = crownMessage
-            .replace(/`?\?member`?/g, winner) // Member mention substitution
-            .replace(/`?\?username`?/g, winner.user.username) // Username substitution
-            .replace(/`?\?tag`?/g, winner.user.tag) // Tag substitution
-            .replace(/`?\?role`?/g, crownRole) // Role substitution
-            .replace(/`?\?points`?/g, points); // Points substitution
-        crownChannel.send({embeds: [new MessageEmbed().setDescription(crownMessage).setColor(guild.me.displayHexColor)]});
-    }
+   // Send crown message
+   if (
+      crownChannel &&
+      crownChannel.viewable &&
+      crownChannel
+         .permissionsFor(guild.me)
+         .has(["SEND_MESSAGES", "EMBED_LINKS"]) &&
+      crownMessage
+   ) {
+      crownMessage = crownMessage
+         .replace(/`?\?member`?/g, winner) // Member mention substitution
+         .replace(/`?\?username`?/g, winner.user.username) // Username substitution
+         .replace(/`?\?tag`?/g, winner.user.tag) // Tag substitution
+         .replace(/`?\?role`?/g, crownRole) // Role substitution
+         .replace(/`?\?points`?/g, points); // Points substitution
+      crownChannel.send({
+         embeds: [
+            new MessageEmbed()
+               .setDescription(crownMessage)
+               .setColor(guild.me.displayHexColor),
+         ],
+      });
+   }
 
-    client.logger.info(`${guild.name}: Assigned crown role to ${winner.user.tag} and reset server points`);
+   client.logger.info(
+      `${guild.name}: Assigned crown role to ${winner.user.tag} and reset server points`
+   );
 }
 
 /**
@@ -239,86 +274,89 @@ async function transferCrown(client, guild, crownRoleId) {
  * @param {Guild} guild
  */
 function scheduleCrown(client, guild) {
+   const { crown_role_id: crownRoleId, crown_schedule: cron } =
+      client.db.settings.selectCrown.get(guild.id);
 
-    const {crown_role_id: crownRoleId, crown_schedule: cron} = client.db.settings.selectCrown.get(guild.id);
+   if (crownRoleId && cron) {
+      guild.job = schedule.scheduleJob(cron, async () => {
+         await client.utils.transferCrown(client, guild, crownRoleId);
+      });
 
-    if (crownRoleId && cron) {
-        guild.job = schedule.scheduleJob(cron, async () => {
-            await client.utils.transferCrown(client, guild, crownRoleId);
-        });
-
-        client.logger.info(`${guild.name}: Successfully scheduled job`);
-    } else {
-        console.error(`${guild.name}: Failed to schedule job`)
-    }
+      client.logger.info(`${guild.name}: Successfully scheduled job`);
+   } else {
+      console.error(`${guild.name}: Failed to schedule job`);
+   }
 }
 
 function createCollections(client, guild) {
-    guild.snipes = new Collection();
-    guild.editSnipes = new Collection();
-    guild.JoinVotingInProgress = new Collection();
-    guild.ships = new Collection();
-    guild.shippingOdds = new Collection();
+   guild.snipes = new Collection();
+   guild.editSnipes = new Collection();
+   guild.JoinVotingInProgress = new Collection();
+   guild.ships = new Collection();
+   guild.shippingOdds = new Collection();
 }
 
 function createProgressBar(percentage) {
-    if (percentage > 100) percentage = 100;
-    if (percentage < 5) percentage = 5;
-    let progressBar = ``;
-    const fives = Math.floor(percentage / 5)
-    //Empty
-    if (fives === 0) {
-        progressBar += emojis.EmptyBegin
-        let i = 0;
-        while (i < 8) progressBar += emojis.EmptyMid, i++;
-        progressBar += emojis.EmptyEnd;
-    } else {
-        if (fives > 1) {
-            let tens = Math.floor(fives / 2)
-            let endWithHalfMid = fives % 2;
+   if (percentage > 100) percentage = 100;
+   if (percentage < 5) percentage = 5;
+   let progressBar = ``;
+   const fives = Math.floor(percentage / 5);
+   //Empty
+   if (fives === 0) {
+      progressBar += emojis.EmptyBegin;
+      let i = 0;
+      while (i < 8) (progressBar += emojis.EmptyMid), i++;
+      progressBar += emojis.EmptyEnd;
+   } else {
+      if (fives > 1) {
+         let tens = Math.floor(fives / 2);
+         let endWithHalfMid = fives % 2;
 
-            for (let i = 0; i < tens; i++) {
-                if (i === 0) progressBar += emojis.FillBegin
-                else if (i === 9) progressBar += emojis.FillEnd
-                else progressBar += emojis.FillMid;
-            }
+         for (let i = 0; i < tens; i++) {
+            if (i === 0) progressBar += emojis.FillBegin;
+            else if (i === 9) progressBar += emojis.FillEnd;
+            else progressBar += emojis.FillMid;
+         }
 
-            const empties = 10 - tens;
-            if (empties > 0) {
-                if (empties === 1 && endWithHalfMid) progressBar += emojis.HalfEnd; //90+
-                else {
-                    if (endWithHalfMid) progressBar += emojis.HalfMid
-                    for (let i = 0; i < empties - endWithHalfMid; i++) {
-                        if (i === empties - endWithHalfMid - 1) progressBar += emojis.EmptyEnd
-                        else progressBar += emojis.EmptyMid
-                    }
-                }
+         const empties = 10 - tens;
+         if (empties > 0) {
+            if (empties === 1 && endWithHalfMid)
+               progressBar += emojis.HalfEnd; //90+
+            else {
+               if (endWithHalfMid) progressBar += emojis.HalfMid;
+               for (let i = 0; i < empties - endWithHalfMid; i++) {
+                  if (i === empties - endWithHalfMid - 1)
+                     progressBar += emojis.EmptyEnd;
+                  else progressBar += emojis.EmptyMid;
+               }
             }
-        } else {
-            progressBar += emojis.HalfBegin
-            let i = 0;
-            while (i < 8) progressBar += emojis.EmptyMid, i++;
-            progressBar += emojis.EmptyEnd;
-        }
-    }
-    return progressBar;
+         }
+      } else {
+         progressBar += emojis.HalfBegin;
+         let i = 0;
+         while (i < 8) (progressBar += emojis.EmptyMid), i++;
+         progressBar += emojis.EmptyEnd;
+      }
+   }
+   return progressBar;
 }
 
 function getRandomInt(min, max) {
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
 function weightedRandom(input) {
-    const array = []; // Just Checking...
-    for (let item in input) {
-        if (input.hasOwnProperty(item)) { // Safety
-            for (let i = 0; i < input[item]; i++) {
-                array.push(item);
-            }
-        }
-    }
-    // Probability Fun
-    return array[Math.floor(Math.random() * array.length)];
+   const array = []; // Just Checking...
+   for (let item in input) {
+      if (input.hasOwnProperty(item)) {
+         // Safety
+         for (let i = 0; i < input[item]; i++) {
+            array.push(item);
+         }
+      }
+   }
+   // Probability Fun
+   return array[Math.floor(Math.random() * array.length)];
 }
 
 /**
@@ -329,76 +367,85 @@ function weightedRandom(input) {
  * @param {string} [color = ''] color
  * @param {string} [outlineColor = ''] outlineColor
  */
-async function generateImgFlipImage(templateID, text0, text1, color = '', outlineColor = '') {
-    return new Promise(((resolve, reject) => {
-        let options = {
-            'method': 'POST',
-            'url': 'https://api.imgflip.com/caption_image',
-            'headers': {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36'
-            },
-            formData: {
-                'template_id': `${templateID}`,
-                'username': config.apiKeys.imgflip.username,
-                'password': config.apiKeys.imgflip.password,
-                'boxes[0][text]': text0,
-                'boxes[1][text]': text1,
-                'boxes[0][color]': color,
-                'boxes[1][color]': color,
-                'boxes[0][outline_color]': outlineColor,
-                'boxes[1][outline_color]': outlineColor
-            }
-        };
-        request(options, function (error, response) {
-            const res = JSON.parse(response.body)
+async function generateImgFlipImage(
+   templateID,
+   text0,
+   text1,
+   color = "",
+   outlineColor = ""
+) {
+   return new Promise((resolve, reject) => {
+      let options = {
+         method: "POST",
+         url: "https://api.imgflip.com/caption_image",
+         headers: {
+            "User-Agent":
+               "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
+         },
+         formData: {
+            template_id: `${templateID}`,
+            username: config.apiKeys.imgflip.username,
+            password: config.apiKeys.imgflip.password,
+            "boxes[0][text]": text0,
+            "boxes[1][text]": text1,
+            "boxes[0][color]": color,
+            "boxes[1][color]": color,
+            "boxes[0][outline_color]": outlineColor,
+            "boxes[1][outline_color]": outlineColor,
+         },
+      };
+      request(options, function (error, response) {
+         const res = JSON.parse(response.body);
 
-            if (res.data.url) resolve(res.data.url || error);
-            else reject(`${error}`)
-        })
-    }))
+         if (res.success == true && res.data.url) {
+            resolve(res.data.url || error);
+         } else reject(res.error_message);
+      });
+   });
 }
 
 async function checkTopGGVote(client, userId) {
-    //If cache has 5 minute old version, send that
-    if (client.votes.has(userId)) {
-
-        let diff = (Math.abs(new Date() - client.votes.get(userId).time)) / 1000 / 60;
-        if (diff <= 5) return new Promise(((resolve, reject) => {
-            resolve(client.votes.get(userId).voted)
-        }))
-    }
-    //otherwise return check topgg api
-    return getTopGGVote(client, userId);
+   //If cache has 5 minute old version, send that
+   if (client.votes.has(userId)) {
+      let diff =
+         Math.abs(new Date() - client.votes.get(userId).time) / 1000 / 60;
+      if (diff <= 5)
+         return new Promise((resolve, reject) => {
+            resolve(client.votes.get(userId).voted);
+         });
+   }
+   //otherwise return check topgg api
+   return getTopGGVote(client, userId);
 }
 
 async function getTopGGVote(client, userId) {
-
-    return new Promise(((resolve, reject) => {
-        let options = {
-            'method': 'GET',
-            'url': `https://top.gg/api/bots/${config.apiKeys.TopGGID}/check?userId=${userId}`,
-            'headers': {
-                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
-                'Authorization': config.apiKeys.TopGGToken
+   return new Promise((resolve, reject) => {
+      let options = {
+         method: "GET",
+         url: `https://top.gg/api/bots/${config.apiKeys.TopGGID}/check?userId=${userId}`,
+         headers: {
+            "User-Agent":
+               "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36",
+            Authorization: config.apiKeys.TopGGToken,
+         },
+      };
+      request(options, function (error, response) {
+         try {
+            const res = JSON.parse(response.body);
+            if (res) {
+               client.votes.set(userId, { time: new Date(), voted: res.voted });
+               resolve(res.voted);
+            } else {
+               client.votes.set(userId, { time: new Date(), voted: 0 });
+               resolve(0);
             }
-        };
-        request(options, function (error, response) {
-            try {
-                const res = JSON.parse(response.body)
-                if (res) {
-                    client.votes.set(userId, {time: new Date(), voted: res.voted})
-                    resolve(res.voted);
-                } else {
-                    client.votes.set(userId, {time: new Date(), voted: 0})
-                    resolve(0);
-                }
-            } catch (e) {
-                console.log(e)
-                client.votes.set(userId, {time: new Date(), voted: 0})
-                resolve(0);
-            }
-        })
-    }))
+         } catch (e) {
+            console.log(e);
+            client.votes.set(userId, { time: new Date(), voted: 0 });
+            resolve(0);
+         }
+      });
+   });
 }
 
 /**
@@ -406,11 +453,11 @@ async function getTopGGVote(client, userId) {
  * @param {string} str
  */
 function spongebobText(str) {
-    let newStr = ''
-    str.split('').forEach((el, idx) => {
-        newStr += idx % 2 === 0 ? el.toLowerCase() : el.toUpperCase()
-    })
-    return newStr
+   let newStr = "";
+   str.split("").forEach((el, idx) => {
+      newStr += idx % 2 === 0 ? el.toLowerCase() : el.toUpperCase();
+   });
+   return newStr;
 }
 
 /**
@@ -419,39 +466,43 @@ function spongebobText(str) {
  * @param {object} guild
  */
 async function replaceMentionsWithNames(content, guild) {
-    const mentionsInMsg = content.match(/<(@!?\d+)>/g)
+   const mentionsInMsg = content.match(/<(@!?\d+)>/g);
 
-    if (mentionsInMsg) {
-        for (let i = 0; i < mentionsInMsg.length; i++) {
-            const id = mentionsInMsg[i].replace('<@', '').replace('!', '').replace('&', '').replace('>', '')
-            const mem = await guild.members.fetch(id)
+   if (mentionsInMsg) {
+      for (let i = 0; i < mentionsInMsg.length; i++) {
+         const id = mentionsInMsg[i]
+            .replace("<@", "")
+            .replace("!", "")
+            .replace("&", "")
+            .replace(">", "");
+         const mem = await guild.members.fetch(id);
 
-            content = content.replace(mentionsInMsg[i], mem.displayName)
-        }
-    }
-    return content;
+         content = content.replace(mentionsInMsg[i], mem.displayName);
+      }
+   }
+   return content;
 }
 
 module.exports = {
-    capitalize,
-    removeElement,
-    trimArray,
-    trimStringFromArray,
-    getRange,
-    getOrdinalNumeral,
-    getCaseNumber,
-    getStatus,
-    replaceKeywords,
-    replaceCrownKeywords,
-    transferCrown,
-    scheduleCrown,
-    getEmojiForJoinVoting,
-    createCollections,
-    createProgressBar,
-    getRandomInt,
-    weightedRandom,
-    generateImgFlipImage,
-    spongebobText,
-    replaceMentionsWithNames,
-    checkTopGGVote
+   capitalize,
+   removeElement,
+   trimArray,
+   trimStringFromArray,
+   getRange,
+   getOrdinalNumeral,
+   getCaseNumber,
+   getStatus,
+   replaceKeywords,
+   replaceCrownKeywords,
+   transferCrown,
+   scheduleCrown,
+   getEmojiForJoinVoting,
+   createCollections,
+   createProgressBar,
+   getRandomInt,
+   weightedRandom,
+   generateImgFlipImage,
+   spongebobText,
+   replaceMentionsWithNames,
+   checkTopGGVote,
 };


### PR DESCRIPTION
The command `hate` has been refactored to use slash commands. However I was not able to get `imgFlip` working so I was not able to fully test out the command, but the slash command behavior behaves the same way as the regular text command.

Should wait for #21 to be merged to clean up commit history.